### PR TITLE
[BUGFIX] Require root rights to install grunt-cli

### DIFF
--- a/build_unix.sh
+++ b/build_unix.sh
@@ -84,7 +84,7 @@ function _post_install_check() {
 }
 
 function _install_packages_simple() {
-  npm install -g grunt-cli
+  sudo npm install -g grunt-cli
 
   if [[ ! -d 'node_modules' ]]; then
     printf "\033[$blau no node_modules folder; executing npm install \033[0m \n";


### PR DESCRIPTION
You need to have root rights to install global
packages via npm.
